### PR TITLE
fix: update synced chat auction history entries

### DIFF
--- a/YTHT_DKP/Core/Comm.lua
+++ b/YTHT_DKP/Core/Comm.lua
@@ -761,9 +761,28 @@ local function HandleHistoryChunk(parts, sender)
         if encounterName == "" then encounterName = nil end
         if instanceName == "" then instanceName = nil end
 
-        -- 去重
+        local isChatAuction = entryId:match("^chat_") ~= nil
+
+        -- 已存在则更新，而不是直接丢弃
         for _, existing in ipairs(DKP.db.auctionHistory) do
             if existing.id and existing.id == entryId and entryId ~= "" then
+                existing.itemLink = itemLink
+                existing.state = state
+                existing.winner = winner
+                existing.winnerChar = winnerChar
+                existing.winnerClass = winnerClass
+                existing.finalBid = finalBid
+                existing.startBid = startBid
+                existing.bidCount = bidCount
+                existing.bids = bids
+                existing.tiedBidders = tiedBidders
+                existing.timestamp = timestamp
+                existing.officer = officer
+                existing.encounterName = encounterName
+                existing.instanceName = instanceName
+                existing.isChatAuction = existing.isChatAuction or isChatAuction
+                existing.confirming = nil
+                if DKP.RefreshAuctionLogUI then DKP.RefreshAuctionLogUI() end
                 return
             end
         end
@@ -813,6 +832,7 @@ local function HandleHistoryChunk(parts, sender)
             officer = officer,
             encounterName = encounterName,
             instanceName = instanceName,
+            isChatAuction = isChatAuction,
         }
         table.insert(DKP.db.auctionHistory, entry)
 


### PR DESCRIPTION
Follow-up to #18

## Summary
- update existing auction history entries in place during sync instead of dropping duplicate ids
- allow `state=ENDED` and winner/finalBid changes from one admin to propagate to other admins
- clear transient local confirm state on synced updates

## Why
PR #18 fixes the client-side duplicate confirm path, but cross-admin prevention still needs `HandleHistoryChunk` to apply state updates for existing `chat_` history entries.

## Testing
- git diff --check