### PR TITLE
Comm: auto-accept sheets sync for admins

### DIFF
--- a/YTHT_DKP/Core/Comm.lua
+++ b/YTHT_DKP/Core/Comm.lua
@@ -1433,14 +1433,7 @@ local function HandleSheetsChunk(parts, sender)
             if DKP.RefreshTableUI then DKP.RefreshTableUI() end
         end
 
-        if DKP.IsAdminMode() then
-            StaticPopup_Show("YTHT_DKP_SYNC_SHEETS",
-                format("收到来自 |cff00FF00%s|r 的掉落列表\n(%d 个副本)\n\n是否覆盖本地数据？",
-                    senderShort, sheetCount),
-                nil, { apply = applySheets })
-        else
-            applySheets()
-        end
+        applySheets()
     end
 end
 


### PR DESCRIPTION
## Summary
- Remove the confirmation popup when admins receive sheets sync from other admins
- Sheets data is now applied immediately for all users (admin and non-admin alike)
- Prevents data inconsistency caused by dismissing/missing the popup during boss encounters

DCCCC reported that the popup was causing confusion and potential data desync between admins.

## Test plan
- [ ] Two admins in raid: boss drops loot → receiving admin should see updated loot list without popup
- [ ] Non-admin sync behavior unchanged (was already auto-accept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)